### PR TITLE
Add `richTextWrap` with support for icons, italics, and bold

### DIFF
--- a/lib/mixins.pug
+++ b/lib/mixins.pug
@@ -118,6 +118,64 @@ mixin richTextWrap(paragraphs, boldFont="bold")
 		- var wordIndex = 0
 		each line, i in options.wrappr.wrap(content.stripped, options.fontSize, options.width)
 			- if (_fontRenderMode === "paths") {
+			-   var d = _makeTextPath(line, options)
+					path(d=d)&attributes(attributes)
+			- } else {
+			-   var attrs = _makeTextAttributes(line, options)
+			-		let wordX = attrs.x
+			-   let skipPad = false
+					text&attributes(attrs)
+						each word, n in line.split(' ')
+							- data = content.data[wordIndex]
+							- wrappr = data.style.includes('font-family: bold') ? _fonts.bold.wrappr : options.wrappr
+							each segment, i in word.split(ICON_SYMBOL)
+								-	if (i != 0) {
+								-		icons.push({ key: data.icons[i-1], x: wordX + options.fontSize*0.2, y: options.y - options.fontSize*0.9, size: options.fontSize })
+								- 	wordX += wrappr.computeWidth(ICON_SYMBOL, options.fontSize);
+										tspan(style='fill: transparent;') #{ICON_SYMBOL}
+								- } else if (n != 0) {
+								- 	segment = " " + segment
+								-	}
+
+								tspan(style=data.style) #{segment}
+								- wordX += wrappr.computeWidth(segment, options.fontSize);
+							- wordIndex += 1;
+			- }
+			- options.y += options.lineHeight
+		- options.y += options.paragraphSpacing
+
+	each img, i in icons
+		+imageFit(assets[img.key], img.x, img.y, img.size, img.size)
+
+mixin richTextWrap(paragraphs, boldFont="bold")
+	- // The following is a hack to render the pug block as the text to be wrapped if the argument is not provided.
+	- if (typeof paragraphs === "undefined") {
+	-   if (block) {
+	-     var _pug_html = pug_html;
+	-     pug_html = "";
+	-     block();
+	-     paragraphs = pug_html;
+	-     pug_html = _pug_html;
+	-   } else {
+	-     throw new Error("Undefined field in +textWrap(): make sure that all fields referenced in the template exist in the card data");
+	-   }
+	- } else if (typeof paragraphs === "string") {
+	-   paragraphs = paragraphs.split("\n");
+	- } else if (!paragraphs) {
+	-   paragraphs = [];
+	- }
+	
+	- var options = _applyTextWrapDefaults(attributes, _fonts)
+	- var icons = []
+	- var debugs = []
+	
+	each text in paragraphs
+		- if (text.txt) text = text.txt
+		- if (!text) text = ""
+		- var content = _parseRichText(text, options, boldFont)
+		- var wordIndex = 0
+		each line, i in options.wrappr.wrap(content.stripped, options.fontSize, options.width)
+			- if (_fontRenderMode === "paths") {
 			- 	var d = _makeTextPath(line, options)
 				path(d=d)&attributes(attributes)
 			- } else {

--- a/lib/mixins.pug
+++ b/lib/mixins.pug
@@ -88,3 +88,61 @@ mixin textWrap(paragraphs)
 			- }
 			- options.y += options.lineHeight
 		- options.y += options.paragraphSpacing
+
+mixin richTextWrap(paragraphs, boldFont="bold")
+	- // The following is a hack to render the pug block as the text to be wrapped if the argument is not provided.
+	- if (typeof paragraphs === "undefined") {
+	-   if (block) {
+	-     var _pug_html = pug_html;
+	-     pug_html = "";
+	-     block();
+	-     paragraphs = pug_html;
+	-     pug_html = _pug_html;
+	-   } else {
+	-     throw new Error("Undefined field in +textWrap(): make sure that all fields referenced in the template exist in the card data");
+	-   }
+	- } else if (typeof paragraphs === "string") {
+	-   paragraphs = paragraphs.split("\n");
+	- } else if (!paragraphs) {
+	-   paragraphs = [];
+	- }
+	
+	- var options = _applyTextWrapDefaults(attributes, _fonts)
+	- var icons = []
+	- var debugs = []
+	
+	each text in paragraphs
+		- if (text.txt) text = text.txt
+		- if (!text) text = ""
+		- var content = _parseRichText(text, options, boldFont)
+		- var wordIndex = 0
+		each line, i in options.wrappr.wrap(content.stripped, options.fontSize, options.width)
+			- if (_fontRenderMode === "paths") {
+			- 	var d = _makeTextPath(line, options)
+				path(d=d)&attributes(attributes)
+			- } else {
+			- 	var attrs = _makeTextAttributes(line, options)
+			- 	let wordX = attrs.x
+			- 	let skipPad = false
+					text&attributes(attrs)
+					each word, n in line.split(' ')
+						- data = content.data[wordIndex]
+						- wrappr = data.style.includes('font-family: bold') ? _fonts.bold.wrappr : options.wrappr
+							each segment, i in word.split(ICON_SYMBOL)
+								- if (i != 0) {
+								- 	icons.push({ key: data.icons[i-1], x: wordX + options.fontSize*0.2, y: options.y - options.fontSize*0.9, size: options.fontSize })
+								- 	wordX += wrappr.computeWidth(ICON_SYMBOL, options.fontSize);
+										tspan(style='fill: transparent;') #{ICON_SYMBOL}
+								- } else if (n != 0) {
+								- 	segment = " " + segment
+								- }
+
+								tspan(style=data.style) #{segment}
+								- wordX += wrappr.computeWidth(segment, options.fontSize);
+						- wordIndex += 1;
+			- }
+			- options.y += options.lineHeight
+		- options.y += options.paragraphSpacing
+		
+	each img, i in icons
+		+imageFit(assets[img.key], img.x, img.y, img.size, img.size)

--- a/lib/render.js
+++ b/lib/render.js
@@ -37,6 +37,9 @@ const DEFAULT_TEXT_WRAP_ATTRIBUTES = {
 	paragraphSpacing: null
 };
 
+// Placeholder for inserting icons into rich text.
+const ICON_SYMBOL = "——"
+
 const MIXINS_PATH = path.join(__dirname, "mixins.pug");
 
 class CardRenderer {
@@ -152,6 +155,38 @@ class CardRenderer {
 			}
 		}
 		return result;
+	}
+
+	
+	_parseRichText(content, options, boldFont="bold") {
+		if (!(boldFont in _fonts)) throw `richTextWrap is missing the \"${boldFont}\" font`
+		const STYLE_CHARS = { '*': `font-family: ${boldFont};`, '_': 'font-style: italic; font-weight: 900;' };
+   		let words = content.split(/\s+/);
+		let currentStyle = new Set();
+   		let wordData = {};
+   		words = words.map((word, i) => {
+			wordData[i] = { icons: [] }
+			word = word.replaceAll(/\[(\w+)(\+?)\]/g, (match, key, includeText) => {
+				wordData[i].icons.push(key)
+				return ICON_SYMBOL + (!!includeText ? key : "")
+			})
+	
+			while (word[0] in STYLE_CHARS) {
+				currentStyle.add(STYLE_CHARS[word[0]])
+				word = word.substring(1)
+			}
+	
+			wordData[i].style = Array.from(currentStyle).join(' ')
+	
+			while (word[word.length - 1] in STYLE_CHARS) {
+				currentStyle.delete(STYLE_CHARS[word[word.length - 1]])
+				word = word.substring(0, word.length - 1)
+			}
+	
+			return word
+		})
+		
+		return { stripped: words.join(' '), data: wordData }
 	}
 
 	render(cardOptions, globalOptions, viewport, extraOptions) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -157,36 +157,34 @@ class CardRenderer {
 		return result;
 	}
 
-	
 	_parseRichText(content, options, boldFont="bold") {
 		if (!(boldFont in _fonts)) throw `richTextWrap is missing the \"${boldFont}\" font`
 		const STYLE_CHARS = { '*': `font-family: ${boldFont};`, '_': 'font-style: italic; font-weight: 900;' };
-   		let words = content.split(/\s+/);
+		let words = content.trim().split(/\s+/);
 		let currentStyle = new Set();
-   		let wordData = {};
-   		words = words.map((word, i) => {
+		let wordData = {};
+		words = words.map((word, i) => {
 			wordData[i] = { icons: [] }
 			word = word.replaceAll(/\[(\w+)(\+?)\]/g, (match, key, includeText) => {
 				wordData[i].icons.push(key)
 				return ICON_SYMBOL + (!!includeText ? key : "")
 			})
-	
+
 			while (word[0] in STYLE_CHARS) {
 				currentStyle.add(STYLE_CHARS[word[0]])
 				word = word.substring(1)
 			}
-	
+
 			wordData[i].style = Array.from(currentStyle).join(' ')
-	
+
 			while (word[word.length - 1] in STYLE_CHARS) {
 				currentStyle.delete(STYLE_CHARS[word[word.length - 1]])
 				word = word.substring(0, word.length - 1)
 			}
-	
+
 			return word
 		})
-		
-		return { stripped: words.join(' '), data: wordData }
+			return { stripped: words.join(' '), data: wordData }
 	}
 
 	render(cardOptions, globalOptions, viewport, extraOptions) {


### PR DESCRIPTION
This PR adds a function called `richTextWrap` that can support limited rich text.

For example, this text
```*Start* with a _[college]college city_ on your [capital+]```
will produce this result:
<img width="349" alt="Screenshot 2024-08-21 at 8 37 48 PM" src="https://github.com/user-attachments/assets/9fc5ee1a-5349-4e96-a27e-863d306540bf">

**Features**
- Any text within square brackets (matching this regex: `/\[(\w+)(\+?)\]/g`) will be converted into an icon
  - If a `+` is added before the closing bracket, the name of the icon will be inserted as well.
  - This icon name must have been specified as an image in the "Advanced" tab
- Text enclosed in `*` symbols will be bolded
- Text enclosed in `_` symbols will be italicized
- Icons can be inserted mid word (to ensure proper wrapping), but italic and bold must have a space next to them to be detected properly.

**How it works**
This works by first parsing the incoming text, and replacing icons with some placeholder text which is roughly the size of the icon (currently "——", which is two em dashes), and then marking every word as italic, bold, both, or neither. Finally each word is rendered as a separate `tspan` element with the correct styling, and icons are inserted at the location of the placeholders.
 
You'll notice that adding a plus at the end of an icon tag (ie. `[capital+]`) will insert the name of the image after the icon. Icons can be detected in the middle of a word segment so that you can bunch them together and ensure that they get wrapped together.

This is definitely a little hacky, but it works and it renders properly when exporting to PDF.